### PR TITLE
SLING-9029 Warning logged by PackageQueuedNotifier if a DistributionPackage does not exist in the callback map

### DIFF
--- a/src/main/java/org/apache/sling/distribution/journal/impl/publisher/PackageQueuedNotifier.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/publisher/PackageQueuedNotifier.java
@@ -63,7 +63,10 @@ public class PackageQueuedNotifier implements EventHandler {
     public void handleEvent(Event event) {
         String packageId = (String) event.getProperty(DistributionEvent.PACKAGE_ID);
         LOG.debug("Handling event for packageId {}", packageId);
-        CompletableFuture<Void> callback = receiveCallbacks.remove(packageId);
+        CompletableFuture<Void> callback = null;
+        if(receiveCallbacks.containsKey(packageId)) {
+            callback = receiveCallbacks.remove(packageId);
+        }
         if (callback != null) {
             callback.complete(null);
         }

--- a/src/main/java/org/apache/sling/distribution/journal/impl/publisher/PackageQueuedNotifier.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/publisher/PackageQueuedNotifier.java
@@ -64,7 +64,7 @@ public class PackageQueuedNotifier implements EventHandler {
         String packageId = (String) event.getProperty(DistributionEvent.PACKAGE_ID);
         LOG.debug("Handling event for packageId {}", packageId);
         CompletableFuture<Void> callback = null;
-        if(receiveCallbacks.containsKey(packageId)) {
+        if (packageId != null) {
             callback = receiveCallbacks.remove(packageId);
         }
         if (callback != null) {


### PR DESCRIPTION
Add a null check as there can be multiple "type" of distribution queues dispatching same event.