### PR TITLE
SLING-9465 - DiscoveryService is activated on all services

### DIFF
--- a/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DiscoveryService.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DiscoveryService.java
@@ -22,6 +22,7 @@ import static java.lang.String.format;
 import static org.apache.sling.distribution.journal.HandlerAdapter.create;
 import static org.apache.sling.commons.scheduler.Scheduler.PROPERTY_SCHEDULER_CONCURRENT;
 import static org.apache.sling.commons.scheduler.Scheduler.PROPERTY_SCHEDULER_PERIOD;
+import static org.osgi.service.component.annotations.ReferencePolicy.DYNAMIC;
 
 import java.io.Closeable;
 import java.util.Dictionary;
@@ -30,6 +31,7 @@ import java.util.Hashtable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.sling.distribution.journal.impl.queue.impl.PubQueueCacheService;
+import org.apache.sling.distribution.journal.impl.shared.DistributionPublisherConfigured;
 import org.apache.sling.distribution.journal.impl.shared.Topics;
 import org.apache.sling.distribution.journal.messages.Messages;
 import org.apache.sling.distribution.journal.messages.Messages.SubscriberConfiguration;
@@ -55,8 +57,7 @@ import org.slf4j.LoggerFactory;
  * Listens for discovery messages and tracks presence of Subscribers as well as
  * the last processed offset of each Subscriber
  *
- * This component uses lazy starting so it is only started when there is at least one Agent
- * that requires it.
+ * This component is only started when there is at least one DistributionSubscriber agent configured.
  *
  * This component is meant to be shared by Publisher agents.
  */
@@ -70,7 +71,10 @@ public class DiscoveryService implements Runnable {
 
     @Reference
     private JournalAvailable journalAvailable;
-    
+
+    @Reference
+    private DistributionPublisherConfigured distributionPublisherConfigured;
+
     @Reference
     private MessagingProvider messagingProvider;
 

--- a/src/main/java/org/apache/sling/distribution/journal/impl/shared/DistributionPublisherConfigured.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/shared/DistributionPublisherConfigured.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.distribution.journal.impl.shared;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.cm.ConfigurationEvent;
+import org.osgi.service.cm.ConfigurationListener;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Component(immediate = true, service = ConfigurationListener.class)
+public class DistributionPublisherConfigured implements ConfigurationListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DistributionPublisherConfigured.class);
+
+    private volatile BundleContext context;
+
+    private ServiceRegistration<DistributionPublisherConfigured> reg;
+
+    private final Object lock = new Object();
+
+    @Activate
+    public void activate(BundleContext context) {
+        this.context = context;
+    }
+
+    @Deactivate
+    public void deactivate() {
+        synchronized (lock) {
+            if (reg != null) {
+                reg.unregister();
+                LOG.info("Unregistered marker service");
+            }
+        }
+    }
+
+    @Override
+    public void configurationEvent(ConfigurationEvent event) {
+        if ("org.apache.sling.distribution.journal.impl.publisher.DistributionPublisherFactory".equals(event.getFactoryPid())
+                && event.getType() != ConfigurationEvent.CM_DELETED) {
+            synchronized (lock) {
+                if (reg == null) {
+                    reg = context.registerService(DistributionPublisherConfigured.class, this, null);
+                    LOG.info("Registered marker service");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Register DistributionPublisherConfigured marker service when at least one DistributionPublisher configuration has existed
* Reference (static) the DistributionPublisherConfigured service from services that are only required with DistributionPublisher