### PR TITLE
SLING-9465 - DiscoveryService is activated on all services

### DIFF
--- a/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DiscoveryService.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DiscoveryService.java
@@ -22,6 +22,7 @@ import static java.lang.String.format;
 import static org.apache.sling.distribution.journal.HandlerAdapter.create;
 import static org.apache.sling.commons.scheduler.Scheduler.PROPERTY_SCHEDULER_CONCURRENT;
 import static org.apache.sling.commons.scheduler.Scheduler.PROPERTY_SCHEDULER_PERIOD;
+import static org.osgi.service.component.annotations.ReferencePolicy.DYNAMIC;
 
 import java.io.Closeable;
 import java.util.Dictionary;
@@ -30,6 +31,7 @@ import java.util.Hashtable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.sling.distribution.journal.impl.queue.impl.PubQueueCacheService;
+import org.apache.sling.distribution.journal.impl.shared.DistributionPublisherConfigured;
 import org.apache.sling.distribution.journal.impl.shared.Topics;
 import org.apache.sling.distribution.journal.messages.Messages;
 import org.apache.sling.distribution.journal.messages.Messages.SubscriberConfiguration;
@@ -55,8 +57,7 @@ import org.slf4j.LoggerFactory;
  * Listens for discovery messages and tracks presence of Subscribers as well as
  * the last processed offset of each Subscriber
  *
- * This component uses lazy starting so it is only started when there is at least one Agent
- * that requires it.
+ * This component is only started when there is at least one DistributionSubscriber agent configured.
  *
  * This component is meant to be shared by Publisher agents.
  */
@@ -70,7 +71,10 @@ public class DiscoveryService implements Runnable {
 
     @Reference
     private JournalAvailable journalAvailable;
-    
+
+    @Reference
+    private DistributionPublisherConfigured distributionPublisherConfigured;
+
     @Reference
     private MessagingProvider messagingProvider;
 

--- a/src/main/java/org/apache/sling/distribution/journal/impl/shared/PublisherConfigurationAvailable.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/shared/PublisherConfigurationAvailable.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.distribution.journal.impl.shared;
+
+import java.io.IOException;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.cm.ConfigurationEvent;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.sling.commons.scheduler.Scheduler.PROPERTY_SCHEDULER_CONCURRENT;
+import static org.apache.sling.commons.scheduler.Scheduler.PROPERTY_SCHEDULER_IMMEDIATE;
+import static org.apache.sling.commons.scheduler.Scheduler.PROPERTY_SCHEDULER_PERIOD;
+
+@Component(
+        property = {
+                PROPERTY_SCHEDULER_CONCURRENT + ":Boolean=false",
+                PROPERTY_SCHEDULER_IMMEDIATE + ":Boolean=false",
+                PROPERTY_SCHEDULER_PERIOD + ":Long=" + 60, // 1 minute
+        }
+)
+public class DistributionPublisherConfigured implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DistributionPublisherConfigured.class);
+
+    private volatile BundleContext context;
+
+    private ServiceRegistration<DistributionPublisherConfigured> reg;
+
+    private final Object lock = new Object();
+
+    @Reference
+    private ConfigurationAdmin configAdmin;
+
+    @Activate
+    public void activate(BundleContext context) {
+        this.context = context;
+    }
+
+    @Deactivate
+    public void deactivate() {
+        synchronized (lock) {
+            if (reg != null) {
+                reg.unregister();
+                LOG.info("Unregistered marker service");
+            }
+        }
+    }
+
+    @Override
+    public void configurationEvent(ConfigurationEvent event) {
+        if ("org.apache.sling.distribution.journal.impl.publisher.DistributionPublisherFactory".equals(event.getFactoryPid())
+                && event.getType() != ConfigurationEvent.CM_DELETED) {
+            synchronized (lock) {
+                if (reg == null) {
+                    reg = context.registerService(DistributionPublisherConfigured.class, this, null);
+                    LOG.info("Registered marker service");
+                }
+            }
+        }
+    }
+
+    @Override
+    public void run() {
+
+        String filter = "(" + Constants.SERVICE_PID + "=" + "org.apache.sling.distribution.journal.impl.publisher.DistributionPublisherFactory" + ")";
+        try {
+            Configuration[] configs = configAdmin.listConfigurations(filter);
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (InvalidSyntaxException e) {
+            e.printStackTrace();
+        }
+        if () {
+
+        }
+    }
+
+    private void publisherConfigurationsAvailable() {
+
+    }
+}

--- a/src/test/java/org/apache/sling/distribution/journal/impl/shared/PublisherConfigurationAvailableTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/impl/shared/PublisherConfigurationAvailableTest.java
@@ -1,0 +1,5 @@
+import junit.framework.TestCase;
+
+public class PublisherConfigurationAvailableTest extends TestCase {
+
+}


### PR DESCRIPTION
Introduces the PublisherConfigurationAvailable marker service which activates when a configuration for a distribution publisher agent could be found.

Services that must only be activated for distribution publisher agents can add a static reference to the marker service.