### PR TITLE
SLING-9464 - Use marker service to activate components only on

### DIFF
--- a/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DiscoveryService.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DiscoveryService.java
@@ -72,6 +72,9 @@ public class DiscoveryService implements Runnable {
     private JournalAvailable journalAvailable;
     
     @Reference
+    private DistributionPublisherMarker publisherMarker;
+    
+    @Reference
     private MessagingProvider messagingProvider;
 
     @Reference

--- a/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DistributionPublisher.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DistributionPublisher.java
@@ -84,13 +84,13 @@ import org.apache.sling.distribution.journal.JournalAvailable;
  * A Publisher SCD agent which produces messages to be consumed by a {@code DistributionSubscriber} agent.
  */
 @Component(
-        service = DistributionPublisherMarker.class, 
+        service = {}, 
         immediate = true,
-        configurationPid = "org.apache.sling.distribution.journal.impl.publisher.DistributionPublisherFactory"
+        configurationPid = DistributionPublisherMarker.CONFIG_PID
 )
 @Designate(ocd = PublisherConfiguration.class, factory = true)
 @ParametersAreNonnullByDefault
-public class DistributionPublisher implements DistributionAgent, DistributionPublisherMarker {
+public class DistributionPublisher implements DistributionAgent {
 
     private final Map<DistributionRequestType, Consumer<PackageMessage>> REQ_TYPES = new HashMap<>();
 

--- a/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DistributionPublisher.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DistributionPublisher.java
@@ -90,7 +90,7 @@ import org.apache.sling.distribution.journal.JournalAvailable;
 )
 @Designate(ocd = PublisherConfiguration.class, factory = true)
 @ParametersAreNonnullByDefault
-public class DistributionPublisher implements DistributionAgent {
+public class DistributionPublisher implements DistributionAgent, DistributionPublisherMarker {
 
     private final Map<DistributionRequestType, Consumer<PackageMessage>> REQ_TYPES = new HashMap<>();
 

--- a/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DistributionPublisher.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DistributionPublisher.java
@@ -84,7 +84,7 @@ import org.apache.sling.distribution.journal.JournalAvailable;
  * A Publisher SCD agent which produces messages to be consumed by a {@code DistributionSubscriber} agent.
  */
 @Component(
-        service = {}, 
+        service = DistributionPublisherMarker.class, 
         immediate = true,
         configurationPid = "org.apache.sling.distribution.journal.impl.publisher.DistributionPublisherFactory"
 )

--- a/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DistributionPublisherMarker.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DistributionPublisherMarker.java
@@ -18,6 +18,13 @@
  */
 package org.apache.sling.distribution.journal.impl.publisher;
 
-public interface DistributionPublisherMarker {
+import org.osgi.service.component.annotations.Component;
+
+@Component(service = DistributionPublisherMarker.class,
+    configurationPid = DistributionPublisherMarker.CONFIG_PID)
+public class DistributionPublisherMarker {
+
+    public static final String CONFIG_PID = "org.apache.sling.distribution.journal.impl.publisher.DistributionPublisherFactory";
+    
 
 }

--- a/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DistributionPublisherMarker.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DistributionPublisherMarker.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.distribution.journal.impl.publisher;
+
+public interface DistributionPublisherMarker {
+
+}

--- a/src/main/java/org/apache/sling/distribution/journal/impl/publisher/PackageRepo.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/publisher/PackageRepo.java
@@ -75,6 +75,9 @@ public class PackageRepo {
 
     @Reference
     private DistributionMetricsService distributionMetricsService;
+    
+    @Reference
+    private DistributionPublisherMarker publisherMarker;
 
     private static final Logger LOG = LoggerFactory.getLogger(PackageRepo.class);
     static final String PACKAGES_ROOT_PATH = "/var/sling/distribution/journal/packages";

--- a/src/main/java/org/apache/sling/distribution/journal/impl/queue/impl/PubQueueCacheService.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/queue/impl/PubQueueCacheService.java
@@ -23,6 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.sling.distribution.journal.impl.shared.DistributionMetricsService;
 import org.apache.sling.distribution.journal.impl.shared.Topics;
+import org.apache.sling.distribution.journal.impl.publisher.DistributionPublisherMarker;
 import org.apache.sling.distribution.journal.impl.queue.OffsetQueue;
 import org.apache.sling.distribution.journal.MessagingProvider;
 import org.apache.sling.distribution.journal.JournalAvailable;
@@ -61,6 +62,9 @@ public class PubQueueCacheService implements Runnable {
      */
     @Reference
     private JournalAvailable journalAvailable;
+    
+    @Reference
+    private DistributionPublisherMarker publisherMarker;
 
     @Reference
     private MessagingProvider messagingProvider;


### PR DESCRIPTION
distribution publisher side