### PR TITLE
SLING-10107 [Refactoring] improve resourceresolver handling

### DIFF
--- a/src/main/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeper.java
+++ b/src/main/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeper.java
@@ -269,7 +269,7 @@ public class BookKeeper implements Closeable {
      *         {@code false} otherwise.
      */
     public boolean sendStoredStatus(int retry) {
-        PackageStatus status = new PackageStatus(statusStore.load());
+        PackageStatus status = new PackageStatus(statusStore.load(bookKeeperResolver));
         return status.sent || sendStoredStatus(status, retry);
     }
 
@@ -307,7 +307,7 @@ public class BookKeeper implements Closeable {
     }
     
     public long loadOffset() {
-        return processedOffsets.load(KEY_OFFSET, -1L);
+        return processedOffsets.load(bookKeeperResolver,KEY_OFFSET, -1L);
     }
 
     public int getRetries(String pubAgentName) {

--- a/src/main/java/org/apache/sling/distribution/journal/bookkeeper/LocalStore.java
+++ b/src/main/java/org/apache/sling/distribution/journal/bookkeeper/LocalStore.java
@@ -24,6 +24,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -76,7 +77,8 @@ public class LocalStore {
         Resource store = parent.getChild(storeId);
 
         if (store != null) {
-            store.adaptTo(ModifiableValueMap.class).putAll(map);
+            Optional.ofNullable(store.adaptTo(ModifiableValueMap.class))
+                .ifPresent(mvm -> mvm.putAll(map));
         } else {
             serviceResolver.create(parent, storeId, map);
         }

--- a/src/test/java/org/apache/sling/distribution/journal/bookkeeper/LocalStoreTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/bookkeeper/LocalStoreTest.java
@@ -41,13 +41,13 @@ public class LocalStoreTest {
     public void storeConsecutiveOffsets() throws InterruptedException, PersistenceException, LoginException {
         ResourceResolver resolver = bookKeeperResolver.get();
         LocalStore offsetStore = new LocalStore(bookKeeperResolver, "packages", "store1");
-        assertThat(offsetStore.load("offset", -1L), equalTo(-1L));
+        assertThat(offsetStore.load(bookKeeperResolver,"offset", -1L), equalTo(-1L));
         offsetStore.store(resolver, "offset", 2L);
         resolver.commit();
-        assertThat(offsetStore.load("offset", -1L), equalTo(2L));
+        assertThat(offsetStore.load(bookKeeperResolver,"offset", -1L), equalTo(2L));
         offsetStore.store(resolver, "offset", 3L);
         resolver.commit();
-        assertThat(offsetStore.load("offset", -1L), equalTo(3L));
+        assertThat(offsetStore.load(bookKeeperResolver,"offset", -1L), equalTo(3L));
     }
 
     @Test
@@ -55,9 +55,9 @@ public class LocalStoreTest {
         ResourceResolver resolver = bookKeeperResolver.get();
         LocalStore offsetStore = new LocalStore(bookKeeperResolver, "packages", "store3");
         offsetStore.store(resolver, "key1", "value1");
-        assertNull(offsetStore.load("key1", String.class));
+        assertNull(offsetStore.load(bookKeeperResolver,"key1", String.class));
         resolver.commit();
-        assertEquals("value1", offsetStore.load("key1", String.class));
+        assertEquals("value1", offsetStore.load(bookKeeperResolver,"key1", String.class));
     }
 
     @Test
@@ -72,8 +72,8 @@ public class LocalStoreTest {
         statusStore.store(resolver, map);
         resolver.commit();
 
-        assertEquals("value1", statusStore.load("key1", String.class));
-        assertEquals(false, statusStore.load("key2", Boolean.class));
+        assertEquals("value1", statusStore.load(bookKeeperResolver,"key1", String.class));
+        assertEquals(false, statusStore.load(bookKeeperResolver,"key2", Boolean.class));
     }
 
     @Test
@@ -91,8 +91,8 @@ public class LocalStoreTest {
         statusStore.store(resolver, "key2", true);
         resolver.commit();
 
-        assertEquals("value1", statusStore.load("key1", String.class));
-        assertEquals(true, statusStore.load("key2", Boolean.class));
+        assertEquals("value1", statusStore.load(bookKeeperResolver,"key1", String.class));
+        assertEquals(true, statusStore.load(bookKeeperResolver,"key2", Boolean.class));
     }
 
 

--- a/src/test/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberTest.java
@@ -18,7 +18,9 @@
  */
 package org.apache.sling.distribution.journal.impl.subscriber;
 
+import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.sling.api.resource.ResourceResolverFactory.SUBSERVICE;
 import static org.apache.sling.distribution.agent.DistributionAgentState.IDLE;
 import static org.apache.sling.distribution.agent.DistributionAgentState.RUNNING;
 import static org.awaitility.Awaitility.await;
@@ -46,6 +48,7 @@ import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.PersistenceException;
@@ -363,14 +366,22 @@ public class SubscriberTest {
     }
 
     private Long getStoredOffset() {
-        LocalStore store = new LocalStore(resolverFactory, BookKeeper.STORE_TYPE_PACKAGE, SUB1_AGENT_NAME);
+        LocalStore store = new LocalStore(getResolver, BookKeeper.STORE_TYPE_PACKAGE, SUB1_AGENT_NAME);
         return store.load(BookKeeper.KEY_OFFSET, Long.class);
     }
 
     private Status getStatus() {
-        LocalStore statusStore = new LocalStore(resolverFactory, BookKeeper.STORE_TYPE_STATUS, SUB1_AGENT_NAME);
+        LocalStore statusStore = new LocalStore(getResolver, BookKeeper.STORE_TYPE_STATUS, SUB1_AGENT_NAME);
         return new BookKeeper.PackageStatus(statusStore.load()).status;
     }
+
+    private Supplier<ResourceResolver> getResolver = () -> {
+        try {
+            return resolverFactory.getServiceResourceResolver(singletonMap(SUBSERVICE, "bookkeeper"));
+        } catch (LoginException e) {
+            return null;
+        }
+    };
 
     private void createResource(String path) throws PersistenceException, LoginException {
         try (ResourceResolver resolver = resolverFactory.getServiceResourceResolver(null)) {
@@ -458,7 +469,7 @@ public class SubscriberTest {
         private WaitFor(Semaphore sem) {
             this.sem = sem;
         }
-    
+
         @Override
         public DistributionPackageInfo answer(InvocationOnMock invocation) throws Throwable {
             sem.acquire();

--- a/src/test/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberTest.java
@@ -367,12 +367,12 @@ public class SubscriberTest {
 
     private Long getStoredOffset() {
         LocalStore store = new LocalStore(getResolver, BookKeeper.STORE_TYPE_PACKAGE, SUB1_AGENT_NAME);
-        return store.load(BookKeeper.KEY_OFFSET, Long.class);
+        return store.load(getResolver,BookKeeper.KEY_OFFSET, Long.class);
     }
 
     private Status getStatus() {
         LocalStore statusStore = new LocalStore(getResolver, BookKeeper.STORE_TYPE_STATUS, SUB1_AGENT_NAME);
-        return new BookKeeper.PackageStatus(statusStore.load()).status;
+        return new BookKeeper.PackageStatus(statusStore.load(getResolver)).status;
     }
 
     private Supplier<ResourceResolver> getResolver = () -> {


### PR DESCRIPTION
I refactored the creation of ResourceResolvers (for the bookkeeper subservice) and moved it into a central supplier, which allows also a better monitoring how often ResourceResolvers are actually opened here.

If necessary, further optimizations can be done from here regarding a more efficient use of ResourceResolvers.