### PR TITLE
SLING-10227: Improvement in distribution logging to log id generated …

### DIFF
--- a/src/main/java/org/apache/sling/distribution/journal/impl/publisher/PackageMessageFactory.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/publisher/PackageMessageFactory.java
@@ -115,6 +115,9 @@ public class PackageMessageFactory {
         try {
             id = UUID.randomUUID().toString();
             storeRef =  binaryStore.put(id, disPkg.createInputStream(), pkgLength);
+            
+            // This log should not be removed as it logs the mapping from pkgId -> id
+            LOG.info("Created package binary for package [{}] with id [{}], length [{}]", disPkg.getId(), id, pkgLength);
         } catch (IOException e) {
             throw new DistributionException(e.getMessage(), e);
         }

--- a/src/main/java/org/apache/sling/distribution/journal/impl/publisher/PackageMessageFactory.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/publisher/PackageMessageFactory.java
@@ -111,13 +111,8 @@ public class PackageMessageFactory {
                 .pkgType(packageBuilder.getType());
 
         String storeRef;
-        String id;
         try {
-            id = UUID.randomUUID().toString();
-            storeRef =  binaryStore.put(id, disPkg.createInputStream(), pkgLength);
-            
-            // This log should not be removed as it logs the mapping from pkgId -> id
-            LOG.info("Created package binary for package [{}] with id [{}], length [{}]", disPkg.getId(), id, pkgLength);
+            storeRef =  binaryStore.put(pkgId, disPkg.createInputStream(), pkgLength);
         } catch (IOException e) {
             throw new DistributionException(e.getMessage(), e);
         }
@@ -128,7 +123,9 @@ public class PackageMessageFactory {
             pkgBuilder.pkgBinary(pkgBinary);
         }
         PackageMessage pipePackage = pkgBuilder.build();
-        LOG.debug("Created distribution package {} with binary id={}", pipePackage, id);
+        
+        LOG.info("Created distribution package [{}] with length [{}]", pkgId, pkgLength);
+        
         disPkg.delete();
         return pipePackage;
     }


### PR DESCRIPTION
…for binary reference and not log reference

- Log the binary reference id separately which can be matched with the package id and should not be removed