### PR TITLE
SLING-10227: Improvement in distribution logging to log id generated …

### DIFF
--- a/src/main/java/org/apache/sling/distribution/journal/impl/publisher/PackageMessageFactory.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/publisher/PackageMessageFactory.java
@@ -124,8 +124,6 @@ public class PackageMessageFactory {
         }
         PackageMessage pipePackage = pkgBuilder.build();
         
-        LOG.info("Created distribution package [{}] with length [{}]", pkgId, pkgLength);
-        
         disPkg.delete();
         return pipePackage;
     }


### PR DESCRIPTION
…for binary reference and not log reference

- Remove redundant logging