### PR TITLE
SLING-11157: Emit content distribution metrics per action type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.distribution.journal.messages</artifactId>
-            <version>0.4.1-T20220225113000-17056a1</version>
+            <version>0.4.1-SNAPSHOT-T20220301165400-17056a1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.distribution.api</artifactId>
-            <version>0.6.0</version>
+            <version>0.6.1-T20220225112300-ef20146</version>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
@@ -145,7 +145,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.distribution.journal.messages</artifactId>
-            <version>0.3.0</version>
+            <version>0.4.1-T20220225113000-17056a1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>

--- a/src/main/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeper.java
+++ b/src/main/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeper.java
@@ -177,7 +177,7 @@ public class BookKeeper implements Closeable {
         log.debug("Invalidating the cache for the package {}", pkgMsg);
         try (ResourceResolver resolver = getServiceResolver(SUBSERVICE_BOOKKEEPER)) {
             if (config.isEditable()) {
-                storeStatus(resolver, new PackageStatus(Status.IMPORTED, offset, pkgMsg.getPubAgentName())); //TODO change IMPORTED status
+                storeStatus(resolver, new PackageStatus(Status.INVALIDATED, offset, pkgMsg.getPubAgentName()));
             }
             storeOffset(resolver, offset);
             resolver.commit();

--- a/src/main/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeper.java
+++ b/src/main/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeper.java
@@ -165,7 +165,7 @@ public class BookKeeper implements Closeable {
 
             packageRetries.clear(pkgMsg.getPubAgentName());
              
-            Event event = new ImportedEvent(pkgMsg, config.getSubAgentName()).toEvent();
+            Event event = new PackageEvent(pkgMsg, config.getSubAgentName(), SUBSERVICE_IMPORTER).toEvent();
             eventAdmin.postEvent(event);
             log.info("Imported distribution package {} at offset={}", pkgMsg, offset);
         } catch (DistributionException | LoginException | IOException | RuntimeException | ImportPostProcessException e) {
@@ -186,7 +186,7 @@ public class BookKeeper implements Closeable {
 
             packageRetries.clear(pkgMsg.getPubAgentName());
 
-            Event event = new ImportedEvent(pkgMsg, config.getSubAgentName()).toEvent();
+            Event event = new PackageEvent(pkgMsg, config.getSubAgentName(), SUBSERVICE_BOOKKEEPER).toEvent();
             eventAdmin.postEvent(event);
             log.info("Invalidated the cache for the package {} at offset={}", pkgMsg, offset);
         }

--- a/src/main/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeper.java
+++ b/src/main/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeper.java
@@ -175,22 +175,18 @@ public class BookKeeper implements Closeable {
         }
     }
 
-    public void invalidatePackage(PackageMessage pkgMsg) {
+    public void invalidateCache(PackageMessage pkgMsg) {
         log.debug("Invalidating the cache for the package {}", pkgMsg);
-        sendEvt(pkgMsg);
         try {
             postProcess(pkgMsg);
-        } catch(ImportPostProcessException e) {
-            log.warn("Exception when invalidating the cache for pubAgentName={}, pkgId={}", pkgMsg.getPubAgentName(), pkgMsg.getPkgId(), e);
-        }
-    }
 
-    private void sendEvt(PackageMessage pkgMsg) {
-        try {
+            packageRetries.clear(pkgMsg.getPubAgentName());
+
             Event event = new ImportedEvent(pkgMsg, config.getSubAgentName()).toEvent();
             eventAdmin.sendEvent(event);
-        } catch (Exception e) {
-            log.warn("Exception when sending event for pkgId={}", pkgMsg.getPkgId(), e);
+            log.info("Invalidated the cache for the package {}", pkgMsg);
+        } catch(ImportPostProcessException e) {
+            log.warn("Exception when invalidating the cache for pkgId={}", pkgMsg.getPkgId(), e);
         }
     }
 

--- a/src/main/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeper.java
+++ b/src/main/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeper.java
@@ -174,7 +174,7 @@ public class BookKeeper implements Closeable {
     }
 
     public void invalidateCache(PackageMessage pkgMsg, long offset) throws LoginException, PersistenceException, ImportPostProcessException {
-        log.debug("Invalidating the cache for the package {}", pkgMsg);
+        log.debug("Invalidating the cache for the package {} at offset={}", pkgMsg, offset);
         try (ResourceResolver resolver = getServiceResolver(SUBSERVICE_BOOKKEEPER)) {
             if (config.isEditable()) {
                 storeStatus(resolver, new PackageStatus(Status.INVALIDATED, offset, pkgMsg.getPubAgentName()));
@@ -188,7 +188,7 @@ public class BookKeeper implements Closeable {
 
             Event event = new ImportedEvent(pkgMsg, config.getSubAgentName()).toEvent();
             eventAdmin.postEvent(event);
-            log.info("Invalidated the cache for the package {}", pkgMsg);
+            log.info("Invalidated the cache for the package {} at offset={}", pkgMsg, offset);
         }
     }
 

--- a/src/main/java/org/apache/sling/distribution/journal/bookkeeper/PackageEvent.java
+++ b/src/main/java/org/apache/sling/distribution/journal/bookkeeper/PackageEvent.java
@@ -33,22 +33,23 @@ import org.apache.sling.distribution.journal.messages.PackageMessage;
 import org.osgi.service.event.Event;
 
 @ParametersAreNonnullByDefault
-class ImportedEvent {
+class PackageEvent {
 
     public static final String PACKAGE_ID = "distribution.package.id";
-    private static final String KIND_IMPORTER = "importer";
     private PackageMessage pkgMsg;
     private String agentName;
+    private String componentKind;
 
-    ImportedEvent(PackageMessage pkgMsg, String agentName) {
+    PackageEvent(PackageMessage pkgMsg, String agentName, String componentKind) {
         this.pkgMsg = pkgMsg;
         this.agentName = agentName;
+        this.componentKind = componentKind;
     }
     
     Event toEvent() {
         String[] paths = pkgMsg.getPaths().toArray(new String[0]);
         Map<String, Object> props = new HashMap<>();
-        props.put(DISTRIBUTION_COMPONENT_KIND, KIND_IMPORTER);
+        props.put(DISTRIBUTION_COMPONENT_KIND, componentKind);
         props.put(DISTRIBUTION_COMPONENT_NAME, agentName);
         props.put(DISTRIBUTION_TYPE, pkgMsg.getReqType().name());
         props.put(DISTRIBUTION_PATHS, paths);

--- a/src/main/java/org/apache/sling/distribution/journal/impl/precondition/StagingPrecondition.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/precondition/StagingPrecondition.java
@@ -71,7 +71,7 @@ public class StagingPrecondition implements Precondition, Runnable {
         if (status == null) {
             return Decision.WAIT;
         }
-        return status == Status.IMPORTED ? Decision.ACCEPT : Decision.SKIP;
+        return status == Status.IMPORTED || status == Status.INVALIDATED ? Decision.ACCEPT : Decision.SKIP;
     }
 
     private synchronized Status getStatus(String subAgentName, long pkgOffset) {

--- a/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DistributionPublisher.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DistributionPublisher.java
@@ -143,10 +143,10 @@ public class DistributionPublisher implements DistributionAgent {
 
     public DistributionPublisher() {
         log = new DefaultDistributionLog(pubAgentName, this.getClass(), DefaultDistributionLog.LogLevel.INFO);
-        reqTypes.put(ADD,    this::sendAndWait);
-        reqTypes.put(DELETE, this::sendAndWait);
+        reqTypes.put(ADD,        this::sendAndWait);
+        reqTypes.put(DELETE,     this::sendAndWait);
         reqTypes.put(INVALIDATE, this::sendAndWait);
-        reqTypes.put(TEST,   this::send);
+        reqTypes.put(TEST,       this::send);
     }
 
     @Activate

--- a/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DistributionPublisher.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/publisher/DistributionPublisher.java
@@ -21,9 +21,7 @@ package org.apache.sling.distribution.journal.impl.publisher;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.sling.distribution.DistributionRequestState.ACCEPTED;
-import static org.apache.sling.distribution.DistributionRequestType.ADD;
-import static org.apache.sling.distribution.DistributionRequestType.DELETE;
-import static org.apache.sling.distribution.DistributionRequestType.TEST;
+import static org.apache.sling.distribution.DistributionRequestType.*;
 import static org.apache.sling.distribution.journal.shared.DistributionMetricsService.timed;
 import static org.apache.sling.distribution.journal.shared.Strings.requireNotBlank;
 
@@ -147,6 +145,7 @@ public class DistributionPublisher implements DistributionAgent {
         log = new DefaultDistributionLog(pubAgentName, this.getClass(), DefaultDistributionLog.LogLevel.INFO);
         reqTypes.put(ADD,    this::sendAndWait);
         reqTypes.put(DELETE, this::sendAndWait);
+        reqTypes.put(INVALIDATE, this::sendAndWait);
         reqTypes.put(TEST,   this::send);
     }
 

--- a/src/main/java/org/apache/sling/distribution/journal/impl/publisher/PackageMessageFactory.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/publisher/PackageMessageFactory.java
@@ -91,6 +91,7 @@ public class PackageMessageFactory {
         switch (request.getRequestType()) {
             case ADD: return createAdd(packageBuilder, resourceResolver, pubAgentName, request);
             case DELETE: return createDelete(packageBuilder, resourceResolver, request, pubAgentName);
+            case INVALIDATE: return createInvalidate(packageBuilder, resourceResolver, request, pubAgentName);
             case TEST: return createTest(packageBuilder, resourceResolver, pubAgentName);
             default: throw new IllegalArgumentException(format("Unsupported request with requestType=%s", request.getRequestType()));
         }
@@ -133,7 +134,21 @@ public class PackageMessageFactory {
         disPkg.delete();
         return pipePackage;
     }
-    
+
+    @Nonnull
+    private PackageMessage createInvalidate(DistributionPackageBuilder packageBuilder, ResourceResolver resourceResolver, DistributionRequest request, String pubAgentName) {
+        String pkgId = UUID.randomUUID().toString();
+        return PackageMessage.builder()
+                .pubSlingId(pubSlingId)
+                .pkgId(pkgId)
+                .pubAgentName(pubAgentName)
+                .paths(Arrays.asList(request.getPaths()))
+                .reqType(ReqType.INVALIDATE)
+                .pkgType(packageBuilder.getType())
+                .userId(resourceResolver.getUserID())
+                .build();
+    }
+
     @Nonnull
     private PackageMessage createDelete(DistributionPackageBuilder packageBuilder, ResourceResolver resourceResolver, DistributionRequest request, String pubAgentName) {
         String pkgId = UUID.randomUUID().toString();

--- a/src/main/java/org/apache/sling/distribution/journal/impl/subscriber/DistributionSubscriber.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/subscriber/DistributionSubscriber.java
@@ -367,14 +367,12 @@ public class DistributionSubscriber {
         PackageMessage.ReqType type = pkgMsg.getReqType();
         try {
             idleCheck.busy(bookKeeper.getRetries(pkgMsg.getPubAgentName()));
-            if (type.equals(INVALIDATE)) {
-                bookKeeper.invalidatePackage(pkgMsg);
+            if (skip) {
+                bookKeeper.removePackage(pkgMsg, info.getOffset());
+            } else if (type.equals(INVALIDATE)) {
+                bookKeeper.invalidateCache(pkgMsg);
             } else {
-                if (skip) {
-                    bookKeeper.removePackage(pkgMsg, info.getOffset());
-                } else {
-                    bookKeeper.importPackage(pkgMsg, info.getOffset(), info.getCreateTime());
-                }
+                bookKeeper.importPackage(pkgMsg, info.getOffset(), info.getCreateTime());
             }
         } finally {
             idleCheck.idle();

--- a/src/main/java/org/apache/sling/distribution/journal/queue/QueueItemFactory.java
+++ b/src/main/java/org/apache/sling/distribution/journal/queue/QueueItemFactory.java
@@ -93,6 +93,8 @@ public final class QueueItemFactory {
             return DistributionRequestType.ADD;
         case DELETE:
             return DistributionRequestType.DELETE;
+        case INVALIDATE:
+            return DistributionRequestType.INVALIDATE;
         case TEST:
             return DistributionRequestType.TEST;
         default:

--- a/src/main/java/org/apache/sling/distribution/journal/shared/DistributionMetricsService.java
+++ b/src/main/java/org/apache/sling/distribution/journal/shared/DistributionMetricsService.java
@@ -331,6 +331,17 @@ public class DistributionMetricsService {
             getNameWithLabel(getMetricName(BASE_COMPONENT, "journal_unavailable_error_code_count"), "error_code", errorCode));
     }
 
+    /**
+     * Counter for all the different package statuses.
+     *
+     * @return a Sling Metric counter
+     */
+    public Counter getPackageStatusCounter(String status) {
+        return getCounter(
+                getNameWithLabel(getMetricName(BASE_COMPONENT, "package_status_count"), "status", status)
+        );
+    }
+
     public <T> GaugeService<T> createGauge(String name, String description, Supplier<T> supplier) {
         return new GaugeService<>(name, description, supplier);
     }

--- a/src/test/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeperTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeperTest.java
@@ -35,6 +35,7 @@ import org.apache.sling.commons.metrics.Counter;
 import org.apache.sling.commons.metrics.Histogram;
 import org.apache.sling.commons.metrics.Meter;
 import org.apache.sling.commons.metrics.Timer;
+import org.apache.sling.distribution.ImportPostProcessException;
 import org.apache.sling.distribution.ImportPostProcessor;
 import org.apache.sling.distribution.common.DistributionException;
 import org.apache.sling.distribution.journal.messages.LogMessage;
@@ -129,9 +130,9 @@ public class BookKeeperTest {
     }
 
     @Test
-    public void testCacheInvalidation() {
+    public void testCacheInvalidation() throws LoginException, PersistenceException, ImportPostProcessException {
         try {
-            bookKeeper.invalidateCache(buildPackageMessage(PackageMessage.ReqType.INVALIDATE));
+            bookKeeper.invalidateCache(buildPackageMessage(PackageMessage.ReqType.INVALIDATE), 10);
         } finally {
             assertThat(bookKeeper.getRetries(PUB_AGENT_NAME), equalTo(0));
         }

--- a/src/test/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeperTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeperTest.java
@@ -122,20 +122,29 @@ public class BookKeeperTest {
     @Test
     public void testPackageImport() throws DistributionException {
         try {
-            bookKeeper.importPackage(buildPackageMessage(), 10, currentTimeMillis());
+            bookKeeper.importPackage(buildPackageMessage(PackageMessage.ReqType.ADD), 10, currentTimeMillis());
         } finally {
             assertThat(bookKeeper.getRetries(PUB_AGENT_NAME), equalTo(0));
         }
     }
 
-    PackageMessage buildPackageMessage() {
+    @Test
+    public void testCacheInvalidation() {
+        try {
+            bookKeeper.invalidateCache(buildPackageMessage(PackageMessage.ReqType.INVALIDATE));
+        } finally {
+            assertThat(bookKeeper.getRetries(PUB_AGENT_NAME), equalTo(0));
+        }
+    }
+
+    PackageMessage buildPackageMessage(PackageMessage.ReqType reqType) {
         PackageMessage msg = mock(PackageMessage.class);
         when(msg.getPkgLength())
                 .thenReturn(100L);
         when(msg.getPubAgentName())
                 .thenReturn(PUB_AGENT_NAME);
         when(msg.getReqType())
-                .thenReturn(PackageMessage.ReqType.ADD);
+                .thenReturn(reqType);
         when(msg.getPaths())
                 .thenReturn(singletonList("/content"));
         when(msg.getPkgId())

--- a/src/test/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeperTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeperTest.java
@@ -122,6 +122,10 @@ public class BookKeeperTest {
 
     @Test
     public void testPackageImport() throws DistributionException {
+        when(distributionMetricsService.getPackageStatusCounter(
+                PackageStatusMessage.Status.IMPORTED.name())
+        ).thenReturn(mock(Counter.class));
+
         try {
             bookKeeper.importPackage(buildPackageMessage(PackageMessage.ReqType.ADD), 10, currentTimeMillis());
         } finally {
@@ -131,6 +135,10 @@ public class BookKeeperTest {
 
     @Test
     public void testCacheInvalidation() throws LoginException, PersistenceException, ImportPostProcessException {
+        when(distributionMetricsService.getPackageStatusCounter(
+                PackageStatusMessage.Status.INVALIDATED.name())
+        ).thenReturn(mock(Counter.class));
+
         try {
             bookKeeper.invalidateCache(buildPackageMessage(PackageMessage.ReqType.INVALIDATE), 10);
         } finally {

--- a/src/test/java/org/apache/sling/distribution/journal/impl/publisher/DistributionPackageFactoryTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/impl/publisher/DistributionPackageFactoryTest.java
@@ -149,6 +149,16 @@ public class DistributionPackageFactoryTest {
         assertThat(sent.getPkgBinary(), nullValue());
         assertThat(sent.getPkgLength(), equalTo(0L));
         assertThat(sent.getPaths(), contains("/test"));
-        
+    }
+
+    @Test
+    public void testInvalidate() throws DistributionException, IOException {
+        DistributionRequest request = new SimpleDistributionRequest(DistributionRequestType.INVALIDATE, "/test");
+
+        PackageMessage sent = publisher.create(packageBuilder, resourceResolver, "pub1agent1", request);
+        assertThat(sent.getReqType(), equalTo(ReqType.INVALIDATE));
+        assertThat(sent.getPkgBinary(), nullValue());
+        assertThat(sent.getPkgLength(), equalTo(0L));
+        assertThat(sent.getPaths(), contains("/test"));
     }
 }

--- a/src/test/java/org/apache/sling/distribution/journal/impl/publisher/DistributionPublisherTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/impl/publisher/DistributionPublisherTest.java
@@ -185,6 +185,12 @@ public class DistributionPublisherTest {
     }
 
     @Test
+    public void executeRequestINVALIDATEAccepted() throws DistributionException, IOException {
+        DistributionRequest request = new SimpleDistributionRequest(DistributionRequestType.INVALIDATE, "/test");
+        executeAndCheck(request);
+    }
+
+    @Test
     public void executeRequestTESTAccepted() throws DistributionException, IOException {
         DistributionRequest request = new SimpleDistributionRequest(DistributionRequestType.TEST, "/test");
         executeAndCheck(request);

--- a/src/test/java/org/apache/sling/distribution/journal/msg/InMemoryProvider.java
+++ b/src/test/java/org/apache/sling/distribution/journal/msg/InMemoryProvider.java
@@ -65,6 +65,11 @@ public class InMemoryProvider implements MessagingProvider {
     }
 
     @Override
+    public String assignTo(Reset reset, long relativeOffset) {
+        return String.format("%s", reset.name());
+    }
+
+    @Override
     public URI getServerUri() {
         try {
             return new URI("http://localhost:12345/dummy");


### PR DESCRIPTION
This PR adds a new metric that counts the amount of package status changes, as described in https://issues.apache.org/jira/browse/SLING-11157

This is related to the addition of the new `INVALIDATE` action to create cache invalidation distribution requests, as described in: https://issues.apache.org/jira/browse/SLING-10585

Metric name: `package_status_count`
Possible Status: `IMPORTED`|`INVALIDATED`|`REMOVED`|`REMOVED_FAILED`