### PR TITLE
SLING-11157: Emit content distribution metrics per action type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <!-- P R O J E C T                                                           -->
     <!-- ======================================================================= -->
     <artifactId>org.apache.sling.distribution.journal</artifactId>
-    <version>0.1.25-SNAPSHOT</version>
+    <version>0.1.25-SNAPSHOT-T20220329121400-fb9c2cb</version>
 
     <name>Apache Sling Journal based Content Distribution - Core bundle</name>
     <description>Implementation of Apache Sling Content Distribution components on top of an append-only persisted log</description>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <!-- P R O J E C T                                                           -->
     <!-- ======================================================================= -->
     <artifactId>org.apache.sling.distribution.journal</artifactId>
-    <version>0.1.25-SNAPSHOT-T20220329121400-fb9c2cb</version>
+    <version>0.1.25-SNAPSHOT</version>
 
     <name>Apache Sling Journal based Content Distribution - Core bundle</name>
     <description>Implementation of Apache Sling Content Distribution components on top of an append-only persisted log</description>

--- a/src/main/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeper.java
+++ b/src/main/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeper.java
@@ -173,6 +173,7 @@ public class BookKeeper implements Closeable {
             Event event = new AppliedEvent(pkgMsg, config.getSubAgentName()).toEvent();
             eventAdmin.postEvent(event);
             log.info("Imported distribution package {} at offset={}", pkgMsg, offset);
+            distributionMetricsService.getPackageStatusCounter(Status.IMPORTED.name()).increment();
         } catch (DistributionException | LoginException | IOException | RuntimeException | ImportPostProcessException e) {
             failure(pkgMsg, offset, e);
         }
@@ -205,6 +206,7 @@ public class BookKeeper implements Closeable {
 
             log.info("Invalidated the cache for the package {} at offset={}", pkgMsg, offset);
 
+            distributionMetricsService.getPackageStatusCounter(Status.IMPORTED.name()).increment();
             distributionMetricsService.getInvalidationProcessDuration().update((currentTimeMillis() - invalidationStartTime), TimeUnit.MILLISECONDS);
             distributionMetricsService.getInvalidationProcessSuccess().increment();
         } catch (LoginException | PersistenceException | InvalidationProcessException e) {
@@ -289,6 +291,7 @@ public class BookKeeper implements Closeable {
         }
         packageRetries.clear(pkgMsg.getPubAgentName());
         context.stop();
+        distributionMetricsService.getPackageStatusCounter(Status.REMOVED.name()).increment();
     }
     
     public void skipPackage(long offset) throws LoginException, PersistenceException {
@@ -381,6 +384,7 @@ public class BookKeeper implements Closeable {
             throw new DistributionException("Error removing failed package", e);
         }
         context.stop();
+        distributionMetricsService.getPackageStatusCounter(Status.REMOVED_FAILED.name()).increment();
     }
 
     private void storeStatus(ResourceResolver resolver, PackageStatus packageStatus) throws PersistenceException {

--- a/src/main/java/org/apache/sling/distribution/journal/shared/DistributionMetricsService.java
+++ b/src/main/java/org/apache/sling/distribution/journal/shared/DistributionMetricsService.java
@@ -341,7 +341,7 @@ public class DistributionMetricsService {
     }
 
     /**
-     * Counter for all the different package statuses.
+     * Counter for all the different package status.
      *
      * @return a Sling Metric counter
      */

--- a/src/main/java/org/apache/sling/distribution/journal/shared/DistributionMetricsService.java
+++ b/src/main/java/org/apache/sling/distribution/journal/shared/DistributionMetricsService.java
@@ -340,6 +340,17 @@ public class DistributionMetricsService {
             getNameWithLabel(getMetricName(BASE_COMPONENT, "journal_unavailable_error_code_count"), "error_code", errorCode));
     }
 
+    /**
+     * Counter for all the different package statuses.
+     *
+     * @return a Sling Metric counter
+     */
+    public Counter getPackageStatusCounter(String status) {
+        return getCounter(
+                getNameWithLabel(getMetricName(BASE_COMPONENT, "package_status_count"), "status", status)
+        );
+    }
+
     public <T> GaugeService<T> createGauge(String name, String description, Supplier<T> supplier) {
         return new GaugeService<>(name, description, supplier);
     }

--- a/src/test/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeperTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeperTest.java
@@ -131,6 +131,10 @@ public class BookKeeperTest {
 
     @Test
     public void testPackageImport() throws DistributionException {
+        when(distributionMetricsService.getPackageStatusCounter(
+                PackageStatusMessage.Status.IMPORTED.name())
+        ).thenReturn(mock(Counter.class));
+
         try {
             bookKeeper.importPackage(buildPackageMessage(PackageMessage.ReqType.ADD), 10, currentTimeMillis());
         } finally {
@@ -140,6 +144,10 @@ public class BookKeeperTest {
 
     @Test
     public void testCacheInvalidation() throws DistributionException {
+        when(distributionMetricsService.getPackageStatusCounter(
+                PackageStatusMessage.Status.IMPORTED.name())
+        ).thenReturn(mock(Counter.class));
+
         try {
             bookKeeper.invalidateCache(buildPackageMessage(PackageMessage.ReqType.INVALIDATE), 10);
         } finally {

--- a/src/test/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberTest.java
@@ -524,6 +524,8 @@ public class SubscriberTest {
             .thenReturn(counter);
         when(distributionMetricsService.getImportPostProcessSuccess())
             .thenReturn(counter);
+        when(distributionMetricsService.getPackageStatusCounter())
+            .thenReturn(counter);
     }
 
     private void assumeNoPrecondition() {

--- a/src/test/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberTest.java
@@ -524,7 +524,7 @@ public class SubscriberTest {
             .thenReturn(counter);
         when(distributionMetricsService.getImportPostProcessSuccess())
             .thenReturn(counter);
-        when(distributionMetricsService.getPackageStatusCounter())
+        when(distributionMetricsService.getPackageStatusCounter(any(String)))
             .thenReturn(counter);
     }
 

--- a/src/test/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberTest.java
@@ -524,7 +524,7 @@ public class SubscriberTest {
             .thenReturn(counter);
         when(distributionMetricsService.getImportPostProcessSuccess())
             .thenReturn(counter);
-        when(distributionMetricsService.getPackageStatusCounter(any(String)))
+        when(distributionMetricsService.getPackageStatusCounter(any(String.class)))
             .thenReturn(counter);
     }
 

--- a/src/test/java/org/apache/sling/distribution/journal/shared/DistributionMetricsServiceTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/shared/DistributionMetricsServiceTest.java
@@ -105,6 +105,7 @@ public class DistributionMetricsServiceTest {
         assertNotNull(metrics.getRemovedFailedPackageDuration());
         assertNotNull(metrics.getRemovedPackageDuration());
         assertNotNull(metrics.getSendStoredStatusDuration());
+        assertNotNull(metrics.getPackageStatusCounter("mockStatus"));
     }
     
     @Test


### PR DESCRIPTION
This PR adds a new metric that counts the amount of package status changes, as described in https://issues.apache.org/jira/browse/SLING-11157

This is related to the addition of the new `INVALIDATE` action to create cache invalidation distribution requests, as described in: https://issues.apache.org/jira/browse/SLING-10585

Metric name: `package_status_count`
Possible Status: `IMPORTED`|`REMOVED`|`REMOVED_FAILED`