### PR TITLE
SLING-11181: Distinguish between permanent and transient package import failures and add metric on successful retries 

### DIFF
--- a/src/main/java/org/apache/sling/distribution/journal/shared/DistributionMetricsService.java
+++ b/src/main/java/org/apache/sling/distribution/journal/shared/DistributionMetricsService.java
@@ -103,6 +103,10 @@ public class DistributionMetricsService {
 
     private Counter invalidationProcessRequest;
 
+    private Counter transientImportErrors;
+
+    private Counter permanentImportErrors;
+
     private BundleContext context;
 
     @Activate
@@ -133,6 +137,8 @@ public class DistributionMetricsService {
         invalidationProcessDuration = getTimer(getMetricName(PUB_COMPONENT, "invalidation_process_duration"));
         invalidationProcessSuccess = getCounter(getMetricName(SUB_COMPONENT, "invalidation_process_success_count"));
         invalidationProcessRequest = getCounter(getMetricName(SUB_COMPONENT, "invalidation_process_request_count"));
+        transientImportErrors = getCounter(getMetricName(SUB_COMPONENT, "transient_import_errors"));
+        permanentImportErrors = getCounter(getMetricName(SUB_COMPONENT, "permanent_import_errors"));
     }
 
     /**
@@ -402,6 +408,10 @@ public class DistributionMetricsService {
     public Counter getInvalidationProcessRequest() {
         return invalidationProcessRequest;
     }
+
+    public Counter getTransientImportErrors() { return transientImportErrors; }
+
+    public Counter getPermanentImportErrors() { return permanentImportErrors; }
 
     public class GaugeService<T> implements Gauge<T>, Closeable {
         

--- a/src/test/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeperTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeperTest.java
@@ -48,6 +48,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import static org.mockito.Matchers.any;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.osgi.service.event.EventAdmin;
 
@@ -108,6 +109,13 @@ public class BookKeeperTest {
                 .thenReturn(mock(Timer.class));
         when(distributionMetricsService.getInvalidationProcessSuccess())
                 .thenReturn(mock(Counter.class));
+        when(distributionMetricsService.getTransientImportErrors())
+                .thenReturn(mock(Counter.class));
+        when(distributionMetricsService.getPermanentImportErrors())
+                .thenReturn(mock(Counter.class));
+        when(distributionMetricsService.getPackageStatusCounter(any(String.class)))
+                .thenReturn(mock(Counter.class));
+
         BookKeeperConfig bkConfig = new BookKeeperConfig("subAgentName", "subSlingId", true, 10, PackageHandling.Extract, "package");
         bookKeeper = new BookKeeper(resolverFactory, distributionMetricsService, packageHandler, eventAdmin, sender, logSender, bkConfig,
             importPostProcessor, invalidationProcessor);
@@ -131,10 +139,6 @@ public class BookKeeperTest {
 
     @Test
     public void testPackageImport() throws DistributionException {
-        when(distributionMetricsService.getPackageStatusCounter(
-                PackageStatusMessage.Status.IMPORTED.name())
-        ).thenReturn(mock(Counter.class));
-
         try {
             bookKeeper.importPackage(buildPackageMessage(PackageMessage.ReqType.ADD), 10, currentTimeMillis());
         } finally {
@@ -144,10 +148,6 @@ public class BookKeeperTest {
 
     @Test
     public void testCacheInvalidation() throws DistributionException {
-        when(distributionMetricsService.getPackageStatusCounter(
-                PackageStatusMessage.Status.IMPORTED.name())
-        ).thenReturn(mock(Counter.class));
-
         try {
             bookKeeper.invalidateCache(buildPackageMessage(PackageMessage.ReqType.INVALIDATE), 10);
         } finally {

--- a/src/test/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberTest.java
@@ -517,6 +517,10 @@ public class SubscriberTest {
                 .thenReturn(timer);
         when(distributionMetricsService.getPackageDistributedDuration())
                 .thenReturn(timer);
+        when(distributionMetricsService.getTransientImportErrors())
+                .thenReturn(counter);
+        when(distributionMetricsService.getPermanentImportErrors())
+                .thenReturn(counter);
 
         when(distributionMetricsService.getImportPostProcessDuration())
             .thenReturn(timer);

--- a/src/test/java/org/apache/sling/distribution/journal/shared/DistributionMetricsServiceTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/shared/DistributionMetricsServiceTest.java
@@ -106,6 +106,8 @@ public class DistributionMetricsServiceTest {
         assertNotNull(metrics.getRemovedPackageDuration());
         assertNotNull(metrics.getSendStoredStatusDuration());
         assertNotNull(metrics.getPackageStatusCounter("mockStatus"));
+        assertNotNull(metrics.getTransientImportErrors());
+        assertNotNull(metrics.getPermanentImportErrors());
     }
     
     @Test


### PR DESCRIPTION
This PR addresses the change in [SLING-11181](https://issues.apache.org/jira/browse/SLING-11181).

We are changing the `failed_package_imports` metric to also include a label with the type of failure, if it is `PERMANENT` and cannot be retried anymore, or if its `TRANSIENT` and will be retried.

Additionally, we are adding a new metric `successfully_retried_package_imports` which provides observability on the number of packages that were retried successfully. We assume that a package was successfully retried when it is imported and the `retryCount` is `> 0`