### PR TITLE
Add metric that tracks the time a package spends in the distribution journal

### DIFF
--- a/src/main/java/org/apache/sling/distribution/journal/shared/DistributionMetricsService.java
+++ b/src/main/java/org/apache/sling/distribution/journal/shared/DistributionMetricsService.java
@@ -83,6 +83,8 @@ public class DistributionMetricsService {
 
     private Timer packageDistributedDuration;
 
+    private Timer packageJournalDistributionDuration;
+
     private Timer buildPackageDuration;
 
     private Timer enqueuePackageDuration;
@@ -120,7 +122,6 @@ public class DistributionMetricsService {
         buildPackageDuration = getTimer(getMetricName(PUB_COMPONENT, "build_package_duration"));
         enqueuePackageDuration = getTimer(getMetricName(PUB_COMPONENT, "enqueue_package_duration"));
         queueCacheFetchCount = getCounter(getMetricName(PUB_COMPONENT, "queue_cache_fetch_count"));
-
         importedPackageSize = getHistogram(getMetricName(SUB_COMPONENT, "imported_package_size"));
         itemsBufferSize = getCounter(getMetricName(SUB_COMPONENT, "items_buffer_size"));
         importedPackageDuration = getTimer(getMetricName(SUB_COMPONENT, "imported_package_duration"));
@@ -130,6 +131,7 @@ public class DistributionMetricsService {
         sendStoredStatusDuration = getTimer(getMetricName(SUB_COMPONENT, "send_stored_status_duration"));
         processQueueItemDuration = getTimer(getMetricName(SUB_COMPONENT, "process_queue_item_duration"));
         packageDistributedDuration = getTimer(getMetricName(SUB_COMPONENT, "request_distributed_duration"));
+        packageJournalDistributionDuration = getTimer(getMetricName(SUB_COMPONENT, "package_journal_distribution_duration"));
         queueAccessErrorCount = getCounter(getMetricName(PUB_COMPONENT, "queue_access_error_count"));
         importPostProcessDuration = getTimer(getMetricName(PUB_COMPONENT, "import_post_process_duration"));
         importPostProcessSuccess = getCounter(getMetricName(SUB_COMPONENT, "import_post_process_success_count"));
@@ -234,7 +236,7 @@ public class DistributionMetricsService {
      */
     public Counter getItemsBufferSize() {
         return itemsBufferSize;
-    }
+    } 
 
     /**
      * Timer capturing the duration in ms of successful packages import operations.
@@ -298,6 +300,16 @@ public class DistributionMetricsService {
      */
     public Timer getPackageDistributedDuration() {
         return packageDistributedDuration;
+    }
+
+    /**
+     * Timer capturing the duration in ms that a package spent in the distribution journal.
+     * The timer starts when the package is enqueued and stops when the package is consumed.
+     *
+     * @return a Sling Metrics timer
+     */
+    public Timer getPackageJournalDistributionDuration() {
+        return packageJournalDistributionDuration;
     }
 
     /**

--- a/src/test/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberTest.java
@@ -517,6 +517,8 @@ public class SubscriberTest {
                 .thenReturn(timer);
         when(distributionMetricsService.getPackageDistributedDuration())
                 .thenReturn(timer);
+        when(distributionMetricsService.getPackageJournalDistributionDuration())
+                .thenReturn(timer);
         when(distributionMetricsService.getTransientImportErrors())
                 .thenReturn(counter);
         when(distributionMetricsService.getPermanentImportErrors())

--- a/src/test/java/org/apache/sling/distribution/journal/shared/DistributionMetricsServiceTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/shared/DistributionMetricsServiceTest.java
@@ -99,6 +99,7 @@ public class DistributionMetricsServiceTest {
         assertNotNull(metrics.getImportedPackageSize());
         assertNotNull(metrics.getItemsBufferSize());
         assertNotNull(metrics.getPackageDistributedDuration());
+        assertNotNull(metrics.getPackageJournalDistributionDuration());
         assertNotNull(metrics.getProcessQueueItemDuration());
         assertNotNull(metrics.getQueueCacheFetchCount());
         assertNotNull(metrics.getQueueAccessErrorCount());


### PR DESCRIPTION
This PR adds a new metric timer with the name: `package_journal_distribution_duration`
This timer starts when the package is enqueued and stops when the package is consumed, and the value is measured in `milliseconds`.

We already have a metric called `request_distributed_duration` that tracks the time since a package is enqueued until it is successfully imported. However, since this timer includes the import of the package content, we are not measuring the latency in the journal.