### PR TITLE
SLING-11809: Set 'overwritePrimaryTypesOfFolders' to false.

### DIFF
--- a/src/main/java/org/apache/sling/distribution/journal/bookkeeper/ContentPackageExtractor.java
+++ b/src/main/java/org/apache/sling/distribution/journal/bookkeeper/ContentPackageExtractor.java
@@ -114,7 +114,7 @@ class ContentPackageExtractor {
     private void installPackage(JcrPackage pack, ErrorListener listener) throws RepositoryException, PackageException, IOException {
         ImportOptions opts = new ImportOptions();
         opts.setIdConflictPolicy(LEGACY);
-        opts.setOverwritePrimaryTypesOfFolders(true);
+        opts.setOverwritePrimaryTypesOfFolders(false);
         opts.setListener(listener);
         opts.setStrict(true);
         if (packageHandling == PackageHandling.Extract) {


### PR DESCRIPTION
[Jira Ticket](https://issues.apache.org/jira/browse/SLING-11809)

By default, overwritePrimaryTypesOfFolders in AEM is set to false, which conflicts with the value set to true in the distribution journal. This mismatch can lead to inconsistencies, as observed with some customers.

To prevent inconsistencies, ensure that the overwritePrimaryTypesOfFolders value in the distribution journal aligns with the default value of false in AEM.