### PR TITLE
SLING-12444 - SubscriberIdleCheck should be registered with hc.tags

### DIFF
--- a/src/main/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeper.java
+++ b/src/main/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeper.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Duration;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -177,7 +178,8 @@ public class BookKeeper {
             Event event = new AppliedEvent(pkgMsg, config.getSubAgentName()).toEvent();
             eventAdmin.postEvent(event);
             long currentImporturationMs = System.currentTimeMillis() - importStartTime;
-            log.info("Imported distribution package {} at offset={} took importDurationMs={}", pkgMsg, offset, currentImporturationMs);
+            Date createdDate = new Date(createdTime);
+            log.info("Imported distribution package {} at offset={} took importDurationMs={} created={}", pkgMsg, offset, currentImporturationMs, createdDate);
             subscriberMetrics.getPackageStatusCounter(pkgMsg.getPubAgentName(), Status.IMPORTED).increment();
         } catch (DistributionException | LoginException | IOException | RuntimeException | ImportPreProcessException |ImportPostProcessException e) {
             failure(pkgMsg, offset, e);

--- a/src/main/java/org/apache/sling/distribution/journal/impl/subscriber/DistributionSubscriber.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/subscriber/DistributionSubscriber.java
@@ -178,7 +178,7 @@ public class DistributionSubscriber {
             AtomicBoolean readyHolder = subscriberReadyStore.getReadyHolder(subAgentName);
 
             idleCheck = new SubscriberReady(subAgentName, config.idleMillies(), config.forceReadyMillies(), readyHolder, System::currentTimeMillis);
-            idleReadyCheck = new SubscriberIdleCheck(context, idleCheck, new String[] { "systemready" });
+            idleReadyCheck = new SubscriberIdleCheck(context, idleCheck, config.subscriberIdleTags());
         } else {
             idleCheck = new NoopIdle();
         }

--- a/src/main/java/org/apache/sling/distribution/journal/impl/subscriber/DistributionSubscriber.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/subscriber/DistributionSubscriber.java
@@ -178,7 +178,7 @@ public class DistributionSubscriber {
             AtomicBoolean readyHolder = subscriberReadyStore.getReadyHolder(subAgentName);
 
             idleCheck = new SubscriberReady(subAgentName, config.idleMillies(), config.forceReadyMillies(), readyHolder, System::currentTimeMillis);
-            idleReadyCheck = new SubscriberIdleCheck(context, idleCheck);
+            idleReadyCheck = new SubscriberIdleCheck(context, idleCheck, new String[] { "systemready" });
         } else {
             idleCheck = new NoopIdle();
         }

--- a/src/main/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberConfiguration.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberConfiguration.java
@@ -56,6 +56,9 @@ public @interface SubscriberConfiguration {
     @AttributeDefinition(name = "subscriberIdleCheck", description = "Defines if we register a subscriber idle health check.")
     boolean subscriberIdleCheck() default false;
 
+    @AttributeDefinition(name = "subscriberIdleTags", description = "Defines the health check tags that the subscriber idle health check should be registered for.")
+    String[] subscriberIdleTags() default {};
+
     @AttributeDefinition(name = "ContentPackageExtractor.overwritePrimaryTypesOfFolders", description = "The flag determines whether the primary node types of folders should be overwritten during content package extraction, with a default value of 'true'.")
     boolean contentPackageExtractorOverwritePrimaryTypesOfFolders() default true;
     

--- a/src/main/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberIdleCheck.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberIdleCheck.java
@@ -27,15 +27,20 @@ import org.apache.felix.hc.api.Result;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
+import javax.annotation.Nullable;
+
 public class SubscriberIdleCheck implements HealthCheck, Closeable {
     static final String CHECK_NAME = "DistributionSubscriber idle";
     private final ServiceRegistration<HealthCheck> reg;
     private final IdleCheck idleCheck;
 
-    public SubscriberIdleCheck(BundleContext context, IdleCheck idleCheck) {
+    public SubscriberIdleCheck(BundleContext context, IdleCheck idleCheck, @Nullable String[] hcTags) {
         this.idleCheck = idleCheck;
         final Dictionary<String, Object> props = new Hashtable<>();
         props.put(HealthCheck.NAME, CHECK_NAME);
+        if (hcTags != null && hcTags.length > 0) {
+            props.put(HealthCheck.TAGS, hcTags);
+        }
         this.reg = context.registerService(HealthCheck.class, this, props);
     }
 

--- a/src/test/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberIdleCheckTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/impl/subscriber/SubscriberIdleCheckTest.java
@@ -48,7 +48,7 @@ public class SubscriberIdleCheckTest {
     @Before
     public void before() {
         context = MockOsgi.newBundleContext();
-        idleCheck = new SubscriberIdleCheck(context, idle);
+        idleCheck = new SubscriberIdleCheck(context, idle, new String[] { "systemready" } );
     }
 
     @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SLING-12444

The SubscriberIdleCheck should be registered with configurable hc.tags, otherwise it will be ignored in health checks.
