### PR TITLE
Add metrics for last commited message pack

### DIFF
--- a/src/main/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeper.java
+++ b/src/main/java/org/apache/sling/distribution/journal/bookkeeper/BookKeeper.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.PersistenceException;
@@ -99,6 +100,7 @@ public class BookKeeper {
     private final boolean errorQueueEnabled;
 
     private final PackageRetries packageRetries = new PackageRetries();
+    private final AtomicLong lastPackageCommitTime = new AtomicLong(0);
     private final LocalStore statusStore;
     private final LocalStore processedOffsets;
     private final LocalStore clearStore;
@@ -126,6 +128,7 @@ public class BookKeeper {
         this.config = config;
 
         subscriberMetrics.currentRetries(packageRetries::getSum);
+        subscriberMetrics.setPackageCommitTime(lastPackageCommitTime::get);
         this.resolverFactory = resolverFactory;
         this.subscriberMetrics = subscriberMetrics;
         // Error queues are enabled when the number
@@ -177,7 +180,7 @@ public class BookKeeper {
             subscriberMetrics
                     .getPackageDistributedDuration()
                     .update((currentTimeMillis() - createdTime.getTime()), TimeUnit.MILLISECONDS);
-
+            lastPackageCommitTime.set(currentTimeMillis());
             // Execute the post-processor
             postProcess(pkgMsg);
 

--- a/src/main/java/org/apache/sling/distribution/journal/bookkeeper/SubscriberMetrics.java
+++ b/src/main/java/org/apache/sling/distribution/journal/bookkeeper/SubscriberMetrics.java
@@ -65,6 +65,9 @@ public class SubscriberMetrics {
     // Number of packages with at least one failure to apply
     private static final String CURRENT_RETRIES = SUB_COMPONENT + "current_retries";
 
+    // Time of the last successful package commit
+    private static final String PACKAGE_COMMIT_TIME = SUB_COMPONENT + "package_commit_time";
+
     // Cumulated size of all packages (parameters: TAG_SUB_NAME, editable (golden publish))
     private static final String IMPORTED_PACKAGE_SIZE = SUB_COMPONENT + "imported_package_size";
 
@@ -289,6 +292,10 @@ public class SubscriberMetrics {
 
     public void currentRetries(Supplier<Integer> retriesCallback) {
         metricsService.gauge(getMetricName(CURRENT_RETRIES, tags), retriesCallback);
+    }
+
+    public void setPackageCommitTime(Supplier<Long> commitTimeCallback) {
+        metricsService.gauge(getMetricName(PACKAGE_COMMIT_TIME, tags), commitTimeCallback);
     }
 
     public void setCurrentImport(CurrentImportInfo currentImport) {


### PR DESCRIPTION
Add new gauge metric `sling_distribution_journal_subscriber_package_commit_time` which sets time when last `PackageMessage` was commit in `BookKeeper.importPackage` method.
This metric could be used to create an alert notifying of a delay in package delivery between different subscriber instances.